### PR TITLE
Improvements on the JSDoc rules to not require js doc for anonymous functions and expressions

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -85,8 +85,8 @@
           "FunctionDeclaration": true,
           "MethodDefinition": true,
           "ClassDeclaration": true,
-          "ArrowFunctionExpression": true,
-          "FunctionExpression": true
+          "ArrowFunctionExpression": false,
+          "FunctionExpression": false
         }
       }
     ],

--- a/eslint.json
+++ b/eslint.json
@@ -1,10 +1,6 @@
 {
-  "extends": [
-    "eslint:recommended"
-  ],
-  "plugins": [
-    "jsdoc"
-  ],
+  "extends": ["eslint:recommended"],
+  "plugins": ["jsdoc"],
   "rules": {
     "brace-style": "error",
     "camelcase": "error",
@@ -16,14 +12,8 @@
       }
     ],
     "curly": "error",
-    "eol-last": [
-      "error",
-      "always"
-    ],
-    "eqeqeq": [
-      "error",
-      "always"
-    ],
+    "eol-last": ["error", "always"],
+    "eqeqeq": ["error", "always"],
     "indent": [
       "error",
       2,
@@ -40,19 +30,13 @@
     "jsdoc/require-param-type": "error",
     "jsdoc/valid-types": "error",
     "key-spacing": "error",
-    "linebreak-style": [
-      "error",
-      "unix"
-    ],
+    "linebreak-style": ["error", "unix"],
     "newline-before-return": "error",
     "no-await-in-loop": "error",
     "no-console": [
       "error",
       {
-        "allow": [
-          "warn",
-          "error"
-        ]
+        "allow": ["warn", "error"]
       }
     ],
     "no-multi-spaces": "error",
@@ -64,33 +48,18 @@
       }
     ],
     "no-var": "error",
-    "object-curly-spacing": [
-      "error",
-      "always"
-    ],
+    "object-curly-spacing": ["error", "always"],
     "padding-line-between-statements": [
       "error",
       {
         "blankLine": "always",
-        "prev": [
-          "const",
-          "let",
-          "var"
-        ],
+        "prev": ["const", "let", "var"],
         "next": "*"
       },
       {
         "blankLine": "any",
-        "prev": [
-          "const",
-          "let",
-          "var"
-        ],
-        "next": [
-          "const",
-          "let",
-          "var"
-        ]
+        "prev": ["const", "let", "var"],
+        "next": ["const", "let", "var"]
       }
     ],
     "prefer-const": [
@@ -121,15 +90,9 @@
         }
       }
     ],
-    "semi": [
-      "error",
-      "always"
-    ],
+    "semi": ["error", "always"],
     "space-before-blocks": "error",
-    "spaced-comment": [
-      "error",
-      "always"
-    ],
+    "spaced-comment": ["error", "always"],
     "space-infix-ops": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint.json"
   ],
   "scripts": {
-    "precommit": "npm run lint",
+    "precommit": "yarn lint",
     "lint": "eslint -c react.json check.js"
   },
   "keywords": [

--- a/react.json
+++ b/react.json
@@ -1,7 +1,4 @@
 {
-  "extends": [
-    "./eslint.json",
-    "plugin:react/recommended"
-  ],
+  "extends": ["./eslint.json", "plugin:react/recommended"],
   "rules": {}
 }


### PR DESCRIPTION
### Change
Require JSDoc only for function declaration, method declaration and class declarations and not for function expressions or anonymous functions.

### Why is this needed? 
Consider this example - right now the rules require jsdoc for arrow functions `checkNumber` and `transform` too. But this PR helps to resolve that.

```js
/**
 * This is just a test.
 */
function test(list) {
  const checkNumber = num => !isNaN(num);
  const transform = num => num * 5 + 1;

  return list.filter(checkNumber).map(transform);
}
```

### Additional changes
 - Reformat files with prettier / line width = 120
 - Use `yarn` instead of `npm`.