### PR TITLE
Add a list of projects following eslint-config-leapfrog

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ For projects using React, include `eslint-config-leapfrog/react` which contains 
 }
 ```
 
+## In the Wild
+
+Following are the projects compliant to these rules. Send us a PR and we'll add you to the list.
+
+1. [just-handlebars-helpers](https://github.com/leapfrogtechnology/just-handlebars-helpers)
+2. [frogtoberfest](https://github.com/leapfrogtechnology/frogtoberfest)
+
 ## License
 
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Following are the projects compliant to these rules. Send us a PR and we'll add 
 1. [just-handlebars-helpers](https://github.com/leapfrogtechnology/just-handlebars-helpers)
 2. [frogtoberfest](https://github.com/leapfrogtechnology/frogtoberfest)
 
+## Using TypeScript?
+
+Use [tslint-config-leapfrog](https://github.com/leapfrogtechnology/tslint-config-leapfrog) if your project uses TypeScript.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
- Add a list of projects following this.
- Recommend tslint-config-leapfrog for the projects using TS / TSLint. 